### PR TITLE
feat: Implement Fail-Fast policy (Task A)

### DIFF
--- a/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
+++ b/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
@@ -30,7 +30,25 @@ public class AsyncProcessor {
     }
     
     // TODO: Task A - Implement processAsyncFailFast (Fail-Fast policy)
-    
+        /**
+     * Task A - Fail-Fast (Atomic Policy)
+     * If any concurrent microservice invocation fails, the entire operation fails 
+     * and no result is produced.
+     */
+    public CompletableFuture<String> processAsyncFailFast(
+            List<Microservice> services, 
+            List<String> messages) {
+        
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        for (int i = 0; i < services.size(); i++) {
+            futures.add(services.get(i).retrieveAsync(messages.get(i)));
+        }
+        
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .thenApply(v -> futures.stream()
+                .map(CompletableFuture::join)
+                .collect(Collectors.joining(" ")));
+    }
     // TODO: Task B - Implement processAsyncFailPartial (Fail-Partial policy)
     
     // TODO: Task C - Implement processAsyncFailSoft (Fail-Soft policy)

--- a/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
+++ b/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
@@ -1,6 +1,9 @@
 package coen448.computablefuture.test;
 
 import org.junit.jupiter.api.Test;
+
+import main.java.coen448.computablefuture.test.AsyncProcessor;
+
 import org.junit.jupiter.api.RepeatedTest;
 import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
@@ -20,7 +23,42 @@ public class AsyncProcessorTest {
         System.out.println("Order: " + order);
     }
     
-    // TODO: Add tests for Fail-Fast policy (Task A)
+    // ============================================================================
+    // FAIL-FAST TESTS (Task A)
+    // ============================================================================
+
+    @Test
+    public void testFailFast_AllServicesSucceed() throws Exception {
+        Microservice s1 = new Microservice("S1");
+        Microservice s2 = new Microservice("S2");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailFast(
+            List.of(s1, s2), List.of("msg1", "msg2"));
+        String result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue(result.contains("S1:MSG1"));
+        assertTrue(result.contains("S2:MSG2"));
+    }
+
+    @Test
+    public void testFailFast_OneServiceFails() {
+        Microservice s1 = new Microservice("S1");
+        Microservice failing = new FailingMicroservice("FAIL");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailFast(
+            List.of(s1, failing), List.of("msg1", "msg2"));
+        assertThrows(ExecutionException.class, 
+            () -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testFailFast_NoDeadlock() {
+        Microservice s1 = new Microservice("S1");
+        Microservice s2 = new Microservice("S2");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailFast(
+            List.of(s1, s2), List.of("msg1", "msg2"));
+        assertDoesNotThrow(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
     // TODO: Add tests for Fail-Partial policy (Task B)
     // TODO: Add tests for Fail-Soft policy (Task C)
 }


### PR DESCRIPTION
- Add processAsyncFailFast method
- Uses CompletableFuture.allOf() for atomic semantics
- Exception propagates when any service fails
- Add 3 comprehensive tests
