### PR TITLE
feat: Implement Fail-Partial policy (Task B)

### DIFF
--- a/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
+++ b/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
@@ -49,7 +49,27 @@ public class AsyncProcessor {
                 .map(CompletableFuture::join)
                 .collect(Collectors.joining(" ")));
     }
+    ////////////////////////////////////////////////////////////////////
     // TODO: Task B - Implement processAsyncFailPartial (Fail-Partial policy)
-    
+        /**
+     * Task B - Fail-Partial (Best-Effort Policy)
+     * Successful services return results, failed services are excluded.
+     */
+    public CompletableFuture<List<String>> processAsyncFailPartial(
+            List<Microservice> services, 
+            List<String> messages) {
+        
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        for (int i = 0; i < services.size(); i++) {
+            futures.add(services.get(i).retrieveAsync(messages.get(i))
+                .exceptionally(ex -> null));
+        }
+        
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .thenApply(v -> futures.stream()
+                .map(CompletableFuture::join)
+                .filter(result -> result != null)
+                .collect(Collectors.toList()));
+    }
     // TODO: Task C - Implement processAsyncFailSoft (Fail-Soft policy)
 }

--- a/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
+++ b/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
@@ -60,5 +60,42 @@ public class AsyncProcessorTest {
         assertDoesNotThrow(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
     }
     // TODO: Add tests for Fail-Partial policy (Task B)
+
+    // ============================================================================
+    // FAIL-PARTIAL TESTS (Task B)
+    // ============================================================================
+
+    @Test
+    public void testFailPartial_AllServicesSucceed() throws Exception {
+        Microservice s1 = new Microservice("S1");
+        Microservice s2 = new Microservice("S2");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<List<String>> future = processor.processAsyncFailPartial(
+            List.of(s1, s2), List.of("msg1", "msg2"));
+        List<String> results = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertEquals(2, results.size());
+        assertTrue(results.stream().anyMatch(r -> r.contains("S1:MSG1")));
+    }
+
+    @Test
+    public void testFailPartial_OneServiceFails() throws Exception {
+        Microservice s1 = new Microservice("S1");
+        Microservice failing = new FailingMicroservice("FAIL");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<List<String>> future = processor.processAsyncFailPartial(
+            List.of(s1, failing), List.of("msg1", "msg2"));
+        List<String> results = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).contains("S1:MSG1"));
+    }
+
+    @Test
+    public void testFailPartial_NoExceptionEscapes() {
+        Microservice failing = new FailingMicroservice("FAIL");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<List<String>> future = processor.processAsyncFailPartial(
+            List.of(failing), List.of("msg1"));
+        assertDoesNotThrow(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
     // TODO: Add tests for Fail-Soft policy (Task C)
 }


### PR DESCRIPTION
Closes #2

## Summary
Implements the Fail-Partial (Best-Effort) policy for concurrent microservices.

## Changes
-  Implemented processAsyncFailPartial method
-  Uses exceptionally(ex -> null) per service
-  Filters out null (failed) results
-  No exceptions escape to caller
-  Added 3 comprehensive tests

## Testing
- testFailPartial_AllServicesSucceed ✓
- testFailPartial_OneServiceFails ✓
- testFailPartial_NoExceptionEscapes ✓

All tests passing!