### PR TITLE
feat: Implement Fail-Soft policy (Task C)

### DIFF
--- a/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
+++ b/src/main/java/coen448/computablefuture/test/AsyncProcessor.java
@@ -72,4 +72,25 @@ public class AsyncProcessor {
                 .collect(Collectors.toList()));
     }
     // TODO: Task C - Implement processAsyncFailSoft (Fail-Soft policy)
+        /**
+     * Task C - Fail-Soft (Fallback Policy)
+     * All failures are replaced with a predefined fallback value.
+     * The computation never fails.
+     */
+    public CompletableFuture<String> processAsyncFailSoft(
+            List<Microservice> services, 
+            List<String> messages,
+            String fallbackValue) {
+        
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        for (int i = 0; i < services.size(); i++) {
+            futures.add(services.get(i).retrieveAsync(messages.get(i))
+                .exceptionally(ex -> fallbackValue));
+        }
+        
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .thenApply(v -> futures.stream()
+                .map(CompletableFuture::join)
+                .collect(Collectors.joining(" ")));
+    }
 }

--- a/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
+++ b/src/test/java/coen448/computablefuture/test/AsyncProcessorTest.java
@@ -97,5 +97,43 @@ public class AsyncProcessorTest {
             List.of(failing), List.of("msg1"));
         assertDoesNotThrow(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
     }
-    // TODO: Add tests for Fail-Soft policy (Task C)
+    // ============================================================================
+    // FAIL-SOFT TESTS (Task C)
+    // ============================================================================
+
+    @Test
+    public void testFailSoft_AllServicesSucceed() throws Exception {
+        Microservice s1 = new Microservice("S1");
+        Microservice s2 = new Microservice("S2");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailSoft(
+            List.of(s1, s2), List.of("msg1", "msg2"), "FALLBACK");
+        String result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue(result.contains("S1:MSG1"));
+        assertTrue(result.contains("S2:MSG2"));
+        assertFalse(result.contains("FALLBACK"));
+    }
+
+    @Test
+    public void testFailSoft_OneServiceFails_UsesFallback() throws Exception {
+        Microservice s1 = new Microservice("S1");
+        Microservice failing = new FailingMicroservice("FAIL");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailSoft(
+            List.of(s1, failing), List.of("msg1", "msg2"), "FALLBACK");
+        String result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue(result.contains("S1:MSG1"));
+        assertTrue(result.contains("FALLBACK"));
+    }
+
+    @Test
+    public void testFailSoft_AlwaysCompletesNormally() {
+        Microservice failing1 = new FailingMicroservice("FAIL1");
+        Microservice failing2 = new FailingMicroservice("FAIL2");
+        AsyncProcessor processor = new AsyncProcessor();
+        CompletableFuture<String> future = processor.processAsyncFailSoft(
+            List.of(failing1, failing2), List.of("msg1", "msg2"), "FALLBACK");
+        assertDoesNotThrow(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
 }


### PR DESCRIPTION
```
Closes #3

## Summary
Implements the Fail-Soft (Fallback) policy - the final required policy.

## Changes
-  Implemented processAsyncFailSoft method
-  Uses exceptionally(ex -> fallbackValue)
-  Always completes successfully
-  Replaces all failures with fallback
-  Added 3 comprehensive tests

## Testing
- testFailSoft_AllServicesSucceed ✓
- testFailSoft_OneServiceFails_UsesFallback ✓
- testFailSoft_AlwaysCompletesNormally ✓